### PR TITLE
Update BytecodeTransformers.java

### DIFF
--- a/src/main/java/am2/preloader/BytecodeTransformers.java
+++ b/src/main/java/am2/preloader/BytecodeTransformers.java
@@ -1242,7 +1242,7 @@ public class BytecodeTransformers implements IClassTransformer{
 					  InsnList new_if = new InsnList();
 					  new_if.add(new VarInsnNode(Opcodes.ALOAD, 1));
 					  new_if.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, method1_searchinstruction_owner.getVal(is_obfuscated), method1_checkinstruction_function, method1_checkinstruction_desc, false));
-					  new_if.add(new IntInsnNode(Opcodes.BIPUSH, 8));
+					  new_if.add(new IntInsnNode(Opcodes.BIPUSH, Integer.BYTES));
 					  LabelNode elseLabel = new LabelNode();
 					  new_if.add(new JumpInsnNode(Opcodes.IF_ICMPNE, elseLabel));
 					  new_if.add(new VarInsnNode(Opcodes.ALOAD, 0));


### PR DESCRIPTION
Important Fix: Fix alterS1EPacketRemoveEntityEffect. A fatal bug that makes player be kicked out when any potion effect ends in all multiplayer and lan games